### PR TITLE
Audio

### DIFF
--- a/application/ApplicationManager.cpp
+++ b/application/ApplicationManager.cpp
@@ -14,7 +14,6 @@ namespace app {
 // static ----------------------------------------
 // public function -------------------------------
 void ApplicationManager::initialize(const Desc& desc) {
-    // （Esc キーで終了しないようにする場合はコメントを外す）
     if (desc.is_close_by_escape_key) {
         s3d::System::SetTerminationTriggers(s3d::UserAction::CloseButtonClicked);
     }

--- a/application/AssetManager.cpp
+++ b/application/AssetManager.cpp
@@ -1,7 +1,8 @@
 #include "AssetManager.hpp"
-
+#include <unordered_map>
 #include <Siv3D/FontAsset.hpp>
 #include <Siv3D/TextureAsset.hpp>
+#include <Siv3D/AudioAsset.hpp>
 #include "FilePath.hpp"
 
 namespace dx {
@@ -14,9 +15,10 @@ namespace app {
 // public function -------------------------------
 void AssetManager::initialize(
     const std::vector<FontDesc>& font_descs,
-    const std::vector<TextureDesc>& texture_descs) {
+    const std::vector<TextureDesc>& texture_descs,
+    const std::vector<AudioDesc>& audio_descs) {
     
-    // 使用するフォントアセットを登録
+    // Font
     for (const auto& desc : font_descs) {
         if (!desc.typeface_string.empty()) {
             s3d::FontAsset::Register(desc.key, desc.size, FilePath::asset_font + desc.typeface_string);
@@ -26,8 +28,22 @@ void AssetManager::initialize(
         }
     }
     
-    for (const s3d::String textureExtension = U".png"; const auto& desc : texture_descs) {
-        s3d::TextureAsset::Register(desc.key, FilePath::asset_texture + desc.path + textureExtension);
+    // Texture
+    for (const s3d::String extension = U".png"; const auto& desc : texture_descs) {
+        s3d::TextureAsset::Register(desc.key, FilePath::asset_texture + desc.path + extension);
+    }
+    
+    // Audio
+    std::unordered_map<AudioDesc::Type, s3d::String> types{
+        { AudioDesc::Type::BGM, U"BGM" },
+        { AudioDesc::Type::SE, U"SE" },
+    };
+    for (const s3d::String extension = U".mp3"; const auto& desc : audio_descs) {
+        const auto key = types.at(desc.type) + U"::" + desc.key;
+        const auto path = FilePath::asset_audio + types.at(desc.type) + U"/" + desc.path + extension;
+        s3d::AudioAsset::Register(
+            types.at(desc.type) + U"::" + desc.key,
+            FilePath::asset_audio + types.at(desc.type) + U"/" + desc.path + extension);
     }
 }
 

--- a/application/AssetManager.hpp
+++ b/application/AssetManager.hpp
@@ -40,11 +40,32 @@ public: // static_const/enum
             const s3d::String& path) :
         key(key), path(path) {}
     };
+
+    struct AudioDesc {
+    public:
+        enum class Type : int {
+            BGM, SE
+        };
+        const Type type;
+        const s3d::String key;
+        const s3d::String path;
+    public:
+        AudioDesc(
+            Type type,
+            const s3d::String& key,
+            const s3d::String& path) :
+        type(type), key(key), path(path) {}
+        AudioDesc(
+            Type type,
+            const s3d::String& key_path) :
+        type(type), key(key_path), path(key_path) {}
+    };
 public: // static
 public: // public function
     void initialize(
-            const std::vector<FontDesc>& font_descs,
-            const std::vector<TextureDesc>& texture_descs);
+        const std::vector<FontDesc>& font_descs,
+        const std::vector<TextureDesc>& texture_descs,
+        const std::vector<AudioDesc>& audio_descs);
     
 private: // field
 private: // private function

--- a/application/AssetManager.hpp
+++ b/application/AssetManager.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
-#include <string>
 #include <vector>
 #include <Siv3D/String.hpp>
 #include <Siv3D/Font.hpp>
 #include "Singleton.hpp"
+#include "AudioType.hpp"
 
 namespace dx {
 namespace app {
@@ -43,22 +43,24 @@ public: // static_const/enum
 
     struct AudioDesc {
     public:
-        enum class Type : int {
-            BGM, SE
-        };
-        const Type type;
+        static std::vector<AudioDesc> loadFromToml();
+    public:
+        const aud::AudioType type;
         const s3d::String key;
         const s3d::String path;
+        const bool is_loop;
     public:
         AudioDesc(
-            Type type,
+            aud::AudioType type,
             const s3d::String& key,
-            const s3d::String& path) :
-        type(type), key(key), path(path) {}
+            const s3d::String& path,
+            const bool is_loop = false) :
+        type(type), key(key), path(path), is_loop(is_loop) {}
         AudioDesc(
-            Type type,
-            const s3d::String& key_path) :
-        type(type), key(key_path), path(key_path) {}
+            aud::AudioType type,
+            const s3d::String& key_path,
+            const bool is_loop = false) :
+        type(type), key(key_path), path(key_path), is_loop(is_loop) {}
     };
 public: // static
 public: // public function

--- a/application/ExecutiveManager.cpp
+++ b/application/ExecutiveManager.cpp
@@ -3,6 +3,7 @@
 #include "MainExecutiveManager.hpp"
 #include "SequenceManager.hpp"
 #include "HotReloadManager.hpp"
+#include "Audio.hpp"
 #include "Log.hpp"
 
 namespace dx {
@@ -30,6 +31,10 @@ bool ExecutiveManager::update() {
 
 void ExecutiveManager::draw() const {
     m_sequencer->draw();
+}
+
+void ExecutiveManager::finalize() {
+    aud::Audio::masterSource()->finalize();
 }
 
 }

--- a/application/ExecutiveManager.cpp
+++ b/application/ExecutiveManager.cpp
@@ -11,7 +11,7 @@ namespace app {
 void ExecutiveManager::initialize() {
     const auto& desc = kanji::app::createExecutiveDesc();
     ApplicationManager::instance()->initialize(desc.application);
-    AssetManager::instance()->initialize(desc.font, desc.texture);
+    AssetManager::instance()->initialize(desc.font, desc.texture, desc.audio);
     m_sequencer = kanji::seq::SequenceManager::instance().get();
     m_sequencer->initialize();
     

--- a/application/ExecutiveManager.hpp
+++ b/application/ExecutiveManager.hpp
@@ -25,6 +25,7 @@ public: // static_const/enum
         ApplicationManager::Desc application;
         std::vector<AssetManager::FontDesc> font;
         std::vector<AssetManager::TextureDesc> texture;
+        std::vector<AssetManager::AudioDesc> audio;
     };
 public: // static
 public: // public function

--- a/application/ExecutiveManager.hpp
+++ b/application/ExecutiveManager.hpp
@@ -32,6 +32,7 @@ public: // public function
     void initialize();
     bool update();
     void draw() const;
+    void finalize() override;
     // void transScene();
 private: // field
     ISequenceManager* m_sequencer = nullptr;

--- a/application/FilePath.cpp
+++ b/application/FilePath.cpp
@@ -10,6 +10,7 @@ namespace app {
 s3d::String FilePath::asset         = U"../KANJI-asset/";
 s3d::String FilePath::asset_font    = asset + U"font/";
 s3d::String FilePath::asset_texture = asset + U"texture/";
+s3d::String FilePath::asset_audio   = asset + U"audio/mp3/";
 s3d::String FilePath::asset_toml    = asset + U"toml/";
 
 // public function -------------------------------

--- a/application/FilePath.hpp
+++ b/application/FilePath.hpp
@@ -9,6 +9,7 @@ public: // static_const/enum
     static s3d::String asset;
     static s3d::String asset_font;
     static s3d::String asset_texture;
+    static s3d::String asset_audio;
     static s3d::String asset_toml;
     
 public: // static

--- a/audio/Audio.cpp
+++ b/audio/Audio.cpp
@@ -1,0 +1,54 @@
+#include "Audio.hpp"
+#include "AudioProxy.hpp"
+#include "AudioSource.hpp"
+#include "Siv3D/AudioAsset.hpp"
+#include "FilePath.hpp"
+
+namespace {
+
+const s3d::String generatePath(dx::aud::AudioType type, const s3d::String& short_path) {
+    static const s3d::String extention = U".mp3";
+    return dx::app::FilePath::asset_audio + dx::denum::toString(type) + U"/" + short_path + extention;
+}
+
+}
+
+namespace dx {
+namespace aud {
+
+
+/* ---------- AudioMgr ---------- */
+
+// static ----------------------------------------
+// public function -------------------------------
+void AudioMgr::Register(const AudioDesc& desc) {
+    AudioProxy proxy(desc);
+    s3d::AudioAsset::Register(
+        proxy.key,
+        generatePath(desc.type, desc.path));
+}
+IAudioSource* AudioMgr::source(const s3d::String& key) {
+    return m_master_source->source(key);
+}
+IAudioSource* AudioMgr::source(const std::vector<s3d::String>& keys) {
+    IAudioSource* ret = m_master_source.get();
+    for (const auto& key : keys) {
+        ret = ret->source(key);
+        if (!ret) { return nullptr; }
+    }
+    return ret;
+}
+void AudioMgr::finalize() {
+    m_master_source->finalize();
+    m_master_source.reset();
+}
+// void Audio::stopAll() { }
+// void Audio::setMasterVolume() { }
+// private function ------------------------------
+// ctor/dtor -------------------------------------
+AudioMgr::AudioMgr(double master_volume, bool is_mute) :
+m_master_source(std::make_shared<AudioSource>(nullptr, master_volume, is_mute)) {}
+
+
+}
+}

--- a/audio/Audio.hpp
+++ b/audio/Audio.hpp
@@ -48,7 +48,7 @@ public: // static
     static IAudioSource* source(const std::vector<s3d::String>& keys) {
         return AudioMgr::instance()->source(keys);
     }
-    static void Finalize() {
+    static void finalize() {
         AudioMgr::instance()->finalize();
     }
 public: // ctor/dtor

--- a/audio/Audio.hpp
+++ b/audio/Audio.hpp
@@ -1,0 +1,60 @@
+#pragma once
+#include "AudioSource.hpp"
+
+namespace dx {
+namespace aud {
+
+using AudioDesc = app::AssetManager::AudioDesc;
+
+
+class AudioMgr : public dx::cmp::Singleton<AudioMgr> {
+public: // static_const/enum
+    using Tag = s3d::String;
+public: // static
+public: // public function
+    void Register(const AudioDesc& desc);
+    const std::shared_ptr<IAudioSource>& masterSource() {
+        return m_master_source;
+    }
+    IAudioSource* source(const s3d::String& key);
+    IAudioSource* source(const std::vector<s3d::String>& keys);
+    void finalize() override;
+    // static void stopAll();
+    // static void setMasterVolume();
+    // static void mute() { s_is_mute = true; }
+    // static bool isMute() { return s_is_mute; }
+private: // field
+    std::shared_ptr<IAudioSource> m_master_source;
+
+private: // private function
+public: // ctor/dtor
+    AudioMgr(double master_volume = 1.0, bool is_mute = false);
+};
+
+class Audio {
+public: // static_const/enum
+    using Tag = s3d::String;
+public: // static
+    static void Register(const AudioDesc& desc) {
+        AudioMgr::instance()->Register(desc);
+    }
+    static const std::shared_ptr<IAudioSource>& masterSource() {
+        return AudioMgr::instance()->masterSource();
+    }
+
+    static IAudioSource* source(const s3d::String& key) {
+        return AudioMgr::instance()->source(key);
+    }
+    static IAudioSource* source(const std::vector<s3d::String>& keys) {
+        return AudioMgr::instance()->source(keys);
+    }
+    static void Finalize() {
+        AudioMgr::instance()->finalize();
+    }
+public: // ctor/dtor
+    Audio() = delete;
+};
+
+
+}
+}

--- a/audio/AudioProxy.cpp
+++ b/audio/AudioProxy.cpp
@@ -1,0 +1,84 @@
+#include "AudioProxy.hpp"
+
+namespace {
+
+const s3d::String generateKey(dx::aud::AudioType type, const s3d::String& short_key) {
+    return dx::denum::toString(type) + U"::" + short_key;
+}
+
+}
+
+namespace dx {
+namespace aud {
+
+
+/* ---------- AudioProxy ---------- */
+
+// static ----------------------------------------
+// public function -------------------------------
+bool AudioProxy::play(const s3d::Duration& duration) const {
+    if (isValid()) {
+        return getReal().play(duration);
+    }
+    else {
+        return false;
+    }
+}
+void AudioProxy::pause(const s3d::Duration& duration) const {
+    if (isValid()) {
+        getReal().pause(duration);
+    }
+}
+void AudioProxy::stop(const s3d::Duration& duration) const {
+    if (isValid()) {
+        getReal().stop(duration);
+    }
+}
+void AudioProxy::playOneShot(double volume, double speed) const {
+    if (isValid()) {
+        getReal().playOneShot(volume, speed);
+    }
+}
+void AudioProxy::stopAllShots() const {
+    if (isValid()) {
+        getReal().stopAllShots();
+    }
+}
+
+void AudioProxy::setVolume(double volume) const {
+    if (isValid()) {
+        getReal().setVolume(volume);
+    }
+}
+
+void AudioProxy::applyMasterVolume(double master_volume) const {
+    if (isValid()) {
+        setVolume(master_volume);
+    }
+}
+
+// private function ------------------------------
+// ctor/dtor -------------------------------------
+AudioProxy::AudioProxy(const AudioDesc& desc) :
+type(desc.type),
+key(generateKey(desc.type, desc.key)),
+m_tags() {}
+
+AudioProxy::AudioProxy(const AudioDesc& desc, const std::vector<AudioTag>& tags) :
+type(desc.type),
+key(generateKey(desc.type, desc.key)),
+m_tags(tags) {}
+
+AudioProxy::AudioProxy(AudioType type, const s3d::String& key) :
+type(type),
+key(key),
+m_tags() {}
+
+AudioProxy::AudioProxy(AudioType type, const s3d::String& key, const std::vector<AudioTag>& tags) :
+type(type),
+key(key),
+m_tags(tags) {}
+
+
+}
+}

--- a/audio/AudioProxy.hpp
+++ b/audio/AudioProxy.hpp
@@ -1,0 +1,53 @@
+#pragma once
+#include <Siv3D/AudioAsset.hpp>
+#include "AssetManager.hpp"
+
+namespace dx {
+namespace aud {
+
+using AudioTag = s3d::String;
+using AudioDesc = app::AssetManager::AudioDesc;
+
+class IAudioSource;
+
+class AudioProxy {
+public: // static_const/enum
+    static AudioProxy Null;
+public: // static
+public: // public function
+    bool hasTag(const AudioTag& tag) const {
+        return std::find(m_tags.begin(), m_tags.end(), tag) != m_tags.end();
+    }
+
+    bool play(const s3d::Duration& duration = s3d::SecondsF(0.0)) const;
+    void pause(const s3d::Duration& duration = s3d::SecondsF(0.0)) const;
+    void stop(const s3d::Duration& duration = s3d::SecondsF(0.0)) const;
+    void playOneShot(double volume = 1.0, double speed = 1.0) const;
+    void stopAllShots() const;
+    
+    void setVolume(double volume) const;
+    void applyMasterVolume(double master_volume) const;
+
+public: // field
+    const AudioType type;
+    const s3d::String key;
+    std::vector<AudioTag> m_tags;
+private: // private function
+    s3d::AudioAsset getReal() const { return s3d::AudioAsset(key); }
+    bool isValid() const {
+        return !key.empty() && s3d::AudioAsset::IsRegistered(key);
+    }
+public: // ctor/dtor
+    AudioProxy(const AudioDesc& desc);
+    AudioProxy(const AudioDesc& desc, const std::vector<AudioTag>& tags);
+    AudioProxy(AudioType type, const s3d::String& short_key);
+    AudioProxy(AudioType type, const s3d::String& short_key, const std::vector<AudioTag>& tags);
+private:
+    AudioProxy() : // 無効値用
+    type(AudioType::BGM),
+    key(U"") {}
+};
+
+
+}
+}

--- a/audio/AudioSource.cpp
+++ b/audio/AudioSource.cpp
@@ -1,0 +1,111 @@
+#include "AudioSource.hpp"
+#include "AudioVolume.hpp"
+#include "AudioProxy.hpp"
+
+namespace dx {
+namespace aud {
+
+/* ---------- AudioSource ---------- */
+
+// static ----------------------------------------
+// public function -------------------------------
+bool AudioSource::addClip(AudioType type, const Key& key, bool with_play) {
+    return addClip(type, key, {}, with_play);
+}
+bool AudioSource::addClip(AudioType type, const Key& key, const std::vector<AudioTag>& tags, bool with_play) {
+    if (m_has_finalized) { return false; }
+    if (!m_clips.contains(key)) {
+        m_clips.insert(std::make_pair(key, std::make_shared<AudioProxy>(type, key, tags)));
+        if (with_play) { return play(key); }
+        else { return true; }
+    }
+    return false;
+}
+
+bool AudioSource::play(const Key& key, const s3d::Duration& duration) {
+    if (m_has_finalized) { return false; }
+    if (m_clips.contains(key)) {
+        return m_clips.at(key)->play(duration);
+    }
+    return false;
+}
+
+void AudioSource::playOneShot(const Key& key) {
+    if (m_has_finalized) { return; }
+    if (m_clips.contains(key)) {
+        return m_clips.at(key)->playOneShot(m_volume.absolute());
+    }
+}
+
+void AudioSource::stopAll(const s3d::Duration& duration) {
+    if (m_has_finalized) { return; }
+    stopAllJustBelow();
+    for (auto& source : m_sources) {
+        source.second->stopAll(duration);
+    }
+}
+void AudioSource::stopAllJustBelow(const s3d::Duration& duration) {
+    if (m_has_finalized) { return; }
+    for (const auto& clip : m_clips) {
+        clip.second->stop(duration);
+    }
+}
+
+void AudioSource::stopTag(const AudioTag& tag, const s3d::Duration& duration) {
+    if (m_has_finalized) { return; }
+    for (const auto& clip : m_clips) {
+        if (clip.second->hasTag(tag)) {
+            clip.second->stop(duration);
+        }
+    }
+    for (auto& source : m_sources) {
+        source.second->stopTag(tag, duration);
+    }
+}
+
+IAudioSource* AudioSource::addSource(const Key& key, double relative, bool is_mute) {
+    m_sources.insert(std::make_pair(key, std::make_shared<AudioSource>(&m_volume, relative, is_mute)));
+    return m_sources.at(key).get();
+}
+void AudioSource::removeSource(const Key& key) {
+    if (m_sources.contains(key)) {
+        m_sources.at(key)->stopAll();
+        m_sources.erase(key);
+    }
+}
+IAudioSource* AudioSource::source(const Key& key) {
+    if (m_sources.contains(key)) {
+        return m_sources.at(key).get();
+    }
+    else {
+        return nullptr;
+    }
+}
+
+void AudioSource::finalize() {
+    if (m_has_finalized) { return; }
+    for (auto& source : m_sources) {
+        source.second->finalize();
+    }
+    stopAllJustBelow();
+    m_has_finalized = true;
+}
+
+void AudioSource::onVolumeChanged() {
+    if (m_has_finalized) { return; }
+    const double absolute_master_volume = m_volume.absolute();
+    for (const auto& clip : m_clips) {
+        clip.second->applyMasterVolume(absolute_master_volume);
+    }
+    for (auto& source : m_sources) {
+        source.second->onVolumeChanged();
+    }
+}
+// private function ------------------------------
+// ctor/dtor -------------------------------------
+AudioSource::AudioSource(const AudioVolume* const parent_volume, double relative, bool is_mute) :
+m_volume(this, parent_volume, relative, is_mute) {}
+
+
+}
+}

--- a/audio/AudioSource.hpp
+++ b/audio/AudioSource.hpp
@@ -1,0 +1,86 @@
+#pragma once
+#include <unordered_map>
+#include <Siv3D/Duration.hpp>
+#include "AssetManager.hpp"
+#include "AudioVolume.hpp"
+
+namespace dx {
+namespace aud {
+
+class AudioProxy;
+
+using AudioTag = s3d::String;
+
+class IAudioSource {
+public:
+    using Key = s3d::String;
+public:
+    virtual bool addClip(AudioType type, const Key& key, bool with_play = false) = 0;
+    virtual bool addClip(AudioType type, const Key& key, const std::vector<AudioTag>& tags, bool with_play = false) = 0;
+    virtual bool play(const Key& key, const s3d::Duration& duration = s3d::SecondsF(0.0)) = 0;
+    virtual void playOneShot(const Key& key) = 0;
+    
+    virtual void stopAll(const s3d::Duration& duration = s3d::SecondsF(0.0)) = 0;
+    virtual void stopAllJustBelow(const s3d::Duration& duration = s3d::SecondsF(0.0)) = 0;
+    virtual void stopTag(const AudioTag& tag, const s3d::Duration& duration = s3d::SecondsF(0.0)) = 0;
+    virtual AudioVolume* volume() = 0;
+
+    virtual IAudioSource* addSource(const Key& key, double relative = 1.0, bool is_mute = false) = 0;
+    virtual void removeSource(const Key& key) = 0;
+    virtual IAudioSource* source(const Key& key) = 0;
+    
+    virtual void finalize() = 0;
+    
+protected:
+    IAudioSource() = default;
+public:
+    virtual ~IAudioSource() = default;
+};
+
+
+class IAudioSourceAsVolumeChangedObserver {
+public:
+    virtual void onVolumeChanged() = 0;
+protected:
+    IAudioSourceAsVolumeChangedObserver() = default;
+public:
+    virtual ~IAudioSourceAsVolumeChangedObserver() = default;
+};
+
+
+class AudioSource final : public IAudioSource, public IAudioSourceAsVolumeChangedObserver {
+public: // static_const/enum
+public: // static
+public: // public function
+    bool addClip(AudioType type, const Key& key, bool with_play = false) override;
+    bool addClip(AudioType type, const Key& key, const std::vector<AudioTag>& tags, bool with_play = false) override;
+    bool play(const Key& key, const s3d::Duration& duration = s3d::SecondsF(0.0)) override;
+    void playOneShot(const Key& key) override;
+    
+    void stopAll(const s3d::Duration& duration = s3d::SecondsF(0.0)) override;
+    void stopAllJustBelow(const s3d::Duration& duration = s3d::SecondsF(0.0)) override;
+    void stopTag(const AudioTag& tag, const s3d::Duration& duration = s3d::SecondsF(0.0)) override;
+    virtual AudioVolume* volume() override { return &m_volume; }
+
+    IAudioSource* addSource(const Key& key, double relative = 1.0, bool is_mute = false) override;
+    void removeSource(const Key& key) override;
+    IAudioSource* source(const Key& key) override;
+    
+    void finalize() override;
+    
+    void onVolumeChanged() override;
+    
+private: // field
+    bool m_has_finalized = false;
+    std::unordered_map<s3d::String, std::shared_ptr<AudioProxy>> m_clips;
+    std::unordered_map<s3d::String, std::shared_ptr<AudioSource>> m_sources;
+    AudioVolume m_volume;
+private: // private function
+public: // ctor/dtor
+    AudioSource(const AudioVolume* const parent_volume, double relative = 1.0, bool is_mute = false);
+    ~AudioSource() override = default;
+};
+
+
+}
+}

--- a/audio/AudioType.cpp
+++ b/audio/AudioType.cpp
@@ -1,0 +1,24 @@
+#include "AudioType.hpp"
+
+namespace dx {
+namespace denum {
+
+template <>
+s3d::String toString(aud::AudioType value) {
+    switch (value) {
+    case aud::AudioType::BGM  : return U"BGM";
+    case aud::AudioType::SE   : return U"SE";
+    case aud::AudioType::VOICE: return U"VOICE";
+    }
+}
+template <>
+s3d::String toLower(aud::AudioType value) {
+    switch (value) {
+    case aud::AudioType::BGM  : return U"bgm";
+    case aud::AudioType::SE   : return U"se";
+    case aud::AudioType::VOICE: return U"voice";
+    }
+}
+
+}
+}

--- a/audio/AudioType.hpp
+++ b/audio/AudioType.hpp
@@ -1,0 +1,21 @@
+#pragma once
+#include "Enum.hpp"
+
+namespace dx {
+namespace aud {
+
+enum class AudioType : int {
+    BGM, SE, VOICE
+};
+
+}
+
+namespace denum {
+
+template <>
+s3d::String toString(aud::AudioType value);
+template <>
+s3d::String toLower(aud::AudioType value);
+
+}
+}

--- a/audio/AudioVolume.cpp
+++ b/audio/AudioVolume.cpp
@@ -1,0 +1,43 @@
+#include "AudioVolume.hpp"
+#include <cassert>
+#include "AudioSource.hpp"
+
+namespace dx {
+namespace aud {
+
+/* ---------- AudioVolume ---------- */
+
+// static ----------------------------------------
+// public function -------------------------------
+AudioVolume::Value AudioVolume::absolute() const {
+    if (m_is_mute) {
+        return 0.0;
+    }
+    else if (m_master){
+        return m_master->absolute() * m_relative;
+    }
+    else {
+        return m_relative;
+    }
+}
+
+void AudioVolume::setRelative(Value relative) {
+    if (m_relative != relative) {
+        m_relative = relative;
+        if (m_observer) {
+            m_observer->onVolumeChanged();
+        }
+    }
+}
+
+// private function ------------------------------
+// ctor/dtor -------------------------------------
+AudioVolume::AudioVolume(IAudioSourceAsVolumeChangedObserver* observer, const AudioVolume* const parent_volume, double relative, bool is_mute) :
+m_master(parent_volume),
+m_relative(relative),
+m_is_mute(is_mute),
+m_observer(observer) {}
+
+
+}
+}

--- a/audio/AudioVolume.hpp
+++ b/audio/AudioVolume.hpp
@@ -1,0 +1,34 @@
+#pragma once
+#include "RangedValue.hpp"
+
+namespace dx {
+namespace aud {
+
+class IAudioSourceAsVolumeChangedObserver;
+
+class AudioVolume {
+public: // static_const/enum
+    using Value = double;
+    using Ratio = cmp::RangedValue<double, 0, 1>;
+public: // static
+public: // public function
+    Value absolute() const;
+    const Ratio& relative() const { return m_relative; }
+    bool isMute() const { return m_is_mute; }
+
+    void setRelative(Value relative);
+    void setMute(bool is_mute) { m_is_mute = is_mute; }
+private: // field
+    const AudioVolume* const m_master;
+    Ratio m_relative; // [0, 1]
+    bool m_is_mute;
+    
+    IAudioSourceAsVolumeChangedObserver* m_observer;
+private: // private function
+public: // ctor/dtor
+    AudioVolume(IAudioSourceAsVolumeChangedObserver* observer, const AudioVolume* const parent_volume, double relative, bool is_mute);
+};
+
+
+}
+}

--- a/component/Enum.hpp
+++ b/component/Enum.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <optional>
+#include <Siv3D/String.hpp>
 
 namespace dx {
 namespace denum {

--- a/component/RangedValue.cpp
+++ b/component/RangedValue.cpp
@@ -1,8 +1,0 @@
-//
-//  RangedValue.cpp
-//  KANJI
-//
-//  Created by 福田和彰 on 2020/12/27.
-//
-
-#include "RangedValue.hpp"

--- a/component/RangedValue.cpp
+++ b/component/RangedValue.cpp
@@ -1,0 +1,8 @@
+//
+//  RangedValue.cpp
+//  KANJI
+//
+//  Created by 福田和彰 on 2020/12/27.
+//
+
+#include "RangedValue.hpp"

--- a/component/RangedValue.hpp
+++ b/component/RangedValue.hpp
@@ -1,0 +1,33 @@
+#pragma once
+#include <cassert>
+
+namespace dx {
+namespace cmp {
+
+template<typename T, int MIN, int MAX>
+struct RangedValue {
+public:
+    [[nodiscard]] operator T() const noexcept {
+        return value;
+    }
+    RangedValue<T, MIN, MAX>& operator =(T another) {
+        assert(inRange(another));
+        value = another;
+        return *this;
+    }
+    bool inRange(T value) const { return min <= value && value <= max; }
+private:
+    T value;
+    const T min;
+    const T max;
+public:
+    RangedValue(T value) :
+    value(value),
+    min(static_cast<T>(MIN)),
+    max(static_cast<T>(MAX)) {
+        *this = value;
+    }
+};
+
+}
+}

--- a/component/identity/Id.hpp
+++ b/component/identity/Id.hpp
@@ -60,16 +60,7 @@ public:
 
 }
 
-#define ID_UOMAP(IDType, ValueType) std::unordered_map<IDType, ValueType, dx::idHash<IDType>>
-
 #define ID_DEFINITION(Type)    \
 class Type;                    \
 using Type##ID = dx::ID<Type>; \
 using Type##IDCR = const dx::ID<Type>&;
-
-#define ID_DEFINITION_NS(NameSpace, Type)   \
-namespace NameSpace {                       \
-    class Type;                             \
-    using Type##ID = dx::ID<Type>;          \
-    using Type##IDCR = const dx::ID<Type>&; \
-}

--- a/component/identity/Id.hpp
+++ b/component/identity/Id.hpp
@@ -62,5 +62,4 @@ public:
 
 #define ID_DEFINITION(Type)    \
 class Type;                    \
-using Type##ID = dx::ID<Type>; \
-using Type##IDCR = const dx::ID<Type>&;
+using Type##ID = dx::ID<Type>;

--- a/component/identity/Id.hpp
+++ b/component/identity/Id.hpp
@@ -1,0 +1,75 @@
+#pragma once
+
+#include <unordered_map>
+#include <Siv3D/FormatInt.hpp>
+
+namespace dx {
+
+template <typename T>
+class ID {
+public: // static_const/enum
+public: // static
+public: // public function
+    bool operator == (const ID<T>& another) const {
+        return m_id == another.m_id;
+    }
+    bool operator != (const ID<T>& another) const {
+        return m_id != another.m_id;
+    }
+    int toInt() const { return m_id; }
+    s3d::String toStr() const { return s3d::ToString(m_id); }
+
+    template<typename DST_ID>
+    DST_ID convert() const { return DST_ID(toInt()); }
+
+    ID<T>& operator ++ () {
+        ++m_id;
+        return *this;
+    }
+private: // field
+    int m_id;
+private: // private function
+public: // ctor/dtor
+    explicit ID(int id): m_id(id) {}
+};
+
+template <typename T, int INVALID_ID>
+class NullableID : public ID<T> {
+public: // static_const/enum
+    static const NullableID<T, INVALID_ID> NULL_ID;
+public: // public function
+    bool isNull() const { return *this == NULL_ID; }
+public: // ctor/dtor
+    explicit NullableID(int id): ID<T>(id) {}
+};
+
+template <typename T, int INVALID_ID>
+const NullableID<T, INVALID_ID> NullableID<T, INVALID_ID>::NULL_ID = NullableID<T, INVALID_ID>(INVALID_ID);
+
+}
+
+namespace std {
+
+template<typename T>
+struct hash<dx::ID<T>> {
+public:
+    size_t operator()(const dx::ID<T>& data) const noexcept {
+        return std::hash<int>()(data.toInt());
+    }
+};
+
+}
+
+#define ID_UOMAP(IDType, ValueType) std::unordered_map<IDType, ValueType, dx::idHash<IDType>>
+
+#define ID_DEFINITION(Type)    \
+class Type;                    \
+using Type##ID = dx::ID<Type>; \
+using Type##IDCR = const dx::ID<Type>&;
+
+#define ID_DEFINITION_NS(NameSpace, Type)   \
+namespace NameSpace {                       \
+    class Type;                             \
+    using Type##ID = dx::ID<Type>;          \
+    using Type##IDCR = const dx::ID<Type>&; \
+}

--- a/dbg/logger/LogDefinition.hpp
+++ b/dbg/logger/LogDefinition.hpp
@@ -1,5 +1,4 @@
 #pragma once
-#include <Siv3D/String.hpp>
 #include "Enum.hpp"
 
 namespace dx {

--- a/dbg/logger/LogDestination.hpp
+++ b/dbg/logger/LogDestination.hpp
@@ -22,7 +22,7 @@ public:
 protected:
     virtual void output(Level level, const Category& category, const s3d::String& filled_body) const = 0;
     s3d::String icon(Category category) const {
-        if (m_category_icon.contains(category))
+        if (m_category_icon.contains(category)) {
             return m_category_icon.at(category);
         }
         else {

--- a/input/gamepad/demo/InputDemoScene.hpp
+++ b/input/gamepad/demo/InputDemoScene.hpp
@@ -8,7 +8,7 @@ namespace dx {
 namespace di {
 
 // di デモ用
-class InputDemoScene : public kanji::seq::KanjiScene {
+class InputDemoScene : public kanji::seq::SceneWithData {
 public: // static_const/enum
     enum class Layout : int {
         Square, Horizontal, Vertical


### PR DESCRIPTION
- Audio: static class。ここからアクセスする
- AudioMgr: AudioSourceのツリーを保持。Audioを通してアクセスされる
- AudioSource: 音源。音声を木構造で分類する。個別に音量(AudioVolume)を持つ
- AudioVolume: 音量。木構造を持ち、ルート〜自身までのVolumeをかけ合わせた値をAudioSourceへ引き渡す
- AudioProxy: 音声。AudioAssetに関数を追加したアダプタクラス
- AudioDesc: 音声ファイル一覧をtomlから読み込んだときの生成物。これをAudio→AudioMgr→s3d::AudioAssetと渡し、実際の音声ファイルを読み込む
- AudioType: BGM/SE/VOICE