### PR TITLE
MasterDataとMasterRepositoryとschemaとtomlとpython

### DIFF
--- a/component/identity/MasterDataRepository.hpp
+++ b/component/identity/MasterDataRepository.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <unordered_map>
-#include "Singleton.hpp"
 
 namespace dx {
 namespace md {
@@ -14,18 +13,15 @@ public: // public getter
     virtual const MasterData* at(ID id) const = 0;
     virtual const std::unordered_map<ID, const std::unique_ptr<MasterData>>& data() const = 0;
 
-private: // ctor/dtor
-    IMasterDataRepository() = default;
+public: // ctor/dtor
 };
 
 
 template <typename ID, typename MasterData>
 class MasterDataRepository :
-    public IMasterDataRepository<ID, MasterData>,
-    public cmp::Singleton<MasterDataRepository<ID, MasterData>> {
+    public IMasterDataRepository<ID, MasterData> {
 public: // static_const/enum
     using Dictionary = std::unordered_map<ID, const std::unique_ptr<MasterData>>;
-    using Base = cmp::Singleton<MasterDataRepository<ID, MasterData>>;
 public: // static
 public: // public function
     bool isExist(ID id) const override { return m_data.contains(id); }
@@ -39,13 +35,10 @@ public: // public function
     }
     const Dictionary& data() const override { return m_data; }
     
-protected: // protected function
-    virtual void initialize() {}
-private: // field
+protected: // field
     Dictionary m_data;
 private: // private function
-private: // ctor/dtor
-    MasterDataRepository() { initialize(); }
+public: // ctor/dtor
 };
 
 

--- a/component/identity/MasterDataRepository.hpp
+++ b/component/identity/MasterDataRepository.hpp
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <unordered_map>
+#include "Singleton.hpp"
+
+namespace dx {
+namespace md {
+
+
+template <typename ID, typename MasterData>
+class IMasterDataRepogitory {
+public: // static_const
+    using Dictionary = std::unordered_map<ID, const std::unique_ptr<MasterData>>;
+public: // public getter
+    virtual bool isExist(ID id) const = 0;
+    virtual const MasterData* at(ID id) const = 0;
+    virtual const Dictionary& data() const = 0;
+
+private: // ctor/dtor
+    IMasterDataRepogitory() = default;
+};
+
+
+template <typename ID, typename MasterData>
+class MasterDataRepository :
+    public IMasterDataRepository<ID, MasterData>,
+    public cmp::Singleton<MasterDataRepository<ID, MasterData>> {
+public: // static_const/enum
+public: // static
+    static bool isExist(ID id) { return instance()->isExist(id); }
+    static const MasterData* at(ID id) { return instance()->at(id); }
+    static const Dictionary& data() { return instance()->data(id); }
+public: // public function
+    bool isExist(ID id) const override { return m_data.contains(id); }
+    const MasterData* at(ID id) const override {
+        if (isExist(id)) {
+            return m_data.at(id);
+        }
+        else {
+            return nullptr;
+        }
+    }
+    const Dictionary& data() const override { return m_data; }
+    
+private: // field
+    Dictionary m_data;
+private: // private function
+public: // ctor/dtor
+};
+
+
+}
+}

--- a/component/identity/MasterDataRepository.hpp
+++ b/component/identity/MasterDataRepository.hpp
@@ -25,14 +25,8 @@ public: // static_const/enum
 public: // static
 public: // public function
     bool isExist(ID id) const override { return m_data.contains(id); }
-    const MasterData* at(ID id) const override {
-        if (isExist(id)) {
-            return m_data.at(id).get();
-        }
-        else {
-            return nullptr;
-        }
-    }
+    // 見つからなければ例外を投げる
+    const MasterData* at(ID id) const override { return m_data.at(id).get(); }
     const Dictionary& data() const override { return m_data; }
     
 protected: // field

--- a/component/identity/MasterDataRepository.hpp
+++ b/component/identity/MasterDataRepository.hpp
@@ -8,16 +8,14 @@ namespace md {
 
 
 template <typename ID, typename MasterData>
-class IMasterDataRepogitory {
-public: // static_const
-    using Dictionary = std::unordered_map<ID, const std::unique_ptr<MasterData>>;
+class IMasterDataRepository {
 public: // public getter
     virtual bool isExist(ID id) const = 0;
     virtual const MasterData* at(ID id) const = 0;
-    virtual const Dictionary& data() const = 0;
+    virtual const std::unordered_map<ID, const std::unique_ptr<MasterData>>& data() const = 0;
 
 private: // ctor/dtor
-    IMasterDataRepogitory() = default;
+    IMasterDataRepository() = default;
 };
 
 
@@ -26,15 +24,14 @@ class MasterDataRepository :
     public IMasterDataRepository<ID, MasterData>,
     public cmp::Singleton<MasterDataRepository<ID, MasterData>> {
 public: // static_const/enum
+    using Dictionary = std::unordered_map<ID, const std::unique_ptr<MasterData>>;
+    using Base = cmp::Singleton<MasterDataRepository<ID, MasterData>>;
 public: // static
-    static bool isExist(ID id) { return instance()->isExist(id); }
-    static const MasterData* at(ID id) { return instance()->at(id); }
-    static const Dictionary& data() { return instance()->data(id); }
 public: // public function
     bool isExist(ID id) const override { return m_data.contains(id); }
     const MasterData* at(ID id) const override {
         if (isExist(id)) {
-            return m_data.at(id);
+            return m_data.at(id).get();
         }
         else {
             return nullptr;
@@ -42,10 +39,13 @@ public: // public function
     }
     const Dictionary& data() const override { return m_data; }
     
+protected: // protected function
+    virtual void initialize() {}
 private: // field
     Dictionary m_data;
 private: // private function
-public: // ctor/dtor
+private: // ctor/dtor
+    MasterDataRepository() { initialize(); }
 };
 
 

--- a/component/identity/Repository.hpp
+++ b/component/identity/Repository.hpp
@@ -1,0 +1,80 @@
+#pragma once
+
+#include <memory>
+#include <unordered_map>
+#include "Singleton.hpp"
+#include "Basic.hpp"
+#include "ID.hpp"
+
+namespace dx {
+
+template <typename T>
+class IRepogitory {
+public: // public getter
+    virtual bool isExist(ID<T> id) const = 0;
+    virtual const T* at(ID<T> id) const = 0;
+public: // public setter
+    virtual T* at(ID<T> id) = 0;
+    virtual bool add(ID<T> id, const T& value) = 0;
+    virtual bool overwrite(ID<T> id, const T& value) = 0;
+    virtual bool erase(ID<T> id) = 0;
+    
+private: // ctor/dtor
+    IRepogitory() = default;
+};
+
+
+template <typename T>
+class Repogitory : dx::cmp::Singleton<Repogitory<T>> {
+public: // static_const/enum
+public: // static
+    static std::unique_ptr<DBImpl<T>>& get() {
+        if (s_instance) {
+            s_instance = STD_MAKE_UNIQUE(DBImpl<T>);
+        }
+        return s_instance;
+    }
+private:
+    static std::unique_ptr<DBImpl<T>> s_instance;
+    
+public: // public getter
+    bool isExist(const ID<T>& id) const {
+        return m_data.count(id) > 0;
+    }
+    const T* at(const ID<T>& id) const {
+        return isExist(id) ? m_data.at(id) : throw std::error;
+    }
+public: // public setter
+    T* at(const ID<T>& id) {
+        return isExist(id) ? m_data.at(id) : nullptr;
+    }
+    bool add(const ID<T>& id, const T& value) {
+        if (!isExist(id)) {
+            m_data.insert(std::make_pair(id, value));
+            return true;
+        }
+        else { return false; }
+    }
+    bool overwrite(const ID<T>& id, const T& value) {
+        if (isExist(id)) {
+            m_data.at(id) = value;
+            return true;
+        }
+        else { return false; }
+    }
+    bool erase(const ID<T>& id) {
+        if (isExist(id)) {
+            m_data.remove(id);
+            return true;
+        }
+        else { return false; }
+    }
+    
+private: // field
+    std::unordered_map<int, T> m_data;
+private: // private function
+private: // ctor/dtor
+    Repogitory() = default;
+};
+
+}

--- a/component/identity/UserDataRepository.hpp
+++ b/component/identity/UserDataRepository.hpp
@@ -65,7 +65,7 @@ public: // public setter
     
 protected: // protected function
     virtual void initialize() {}
-private: // field
+protected: // field
     Dictionary m_data;
 private: // private function
 private: // ctor/dtor

--- a/component/identity/UserDataRepository.hpp
+++ b/component/identity/UserDataRepository.hpp
@@ -31,9 +31,6 @@ class UserDataRepository :
     public cmp::Singleton<UserDataRepository<ID, UserData>> {
 public: // static_const/enum
 public: // static
-    static bool isExist(ID id) { return instance()->isExist(id); }
-    static const UserData* at(ID id) { return instance()->at(id); }
-    static const Dictionary& data() { return instance()->data(id); }
 public: // public getter
     bool isExist(ID id) const override { return m_data.contains(id); }
     const UserData* at(ID id) const override {
@@ -66,10 +63,13 @@ public: // public setter
         }
     }
     
+protected: // protected function
+    virtual void initialize() {}
 private: // field
     Dictionary m_data;
 private: // private function
-public: // ctor/dtor
+private: // ctor/dtor
+    UserDataRepository() { initialize(); }
 };
 
 

--- a/component/identity/UserDataRepository.hpp
+++ b/component/identity/UserDataRepository.hpp
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <unordered_map>
+#include "Singleton.hpp"
+
+namespace dx {
+namespace ud {
+
+
+template <typename ID, typename UserData>
+class IUserDataRepogitory {
+public: // static_const
+    using Dictionary = std::unordered_map<ID, const std::unique_ptr<UserData>>;
+public: // public getter
+    virtual bool isExist(ID id) const = 0;
+    virtual const UserData* at(ID id) const = 0;
+    virtual const Dictionary& data() const = 0;
+public: // public setter
+    virtual UserData* at(ID id) = 0;
+    virtual bool add(ID<T> id, const T& value) = 0;
+    virtual bool erase(ID<T> id) = 0;
+
+private: // ctor/dtor
+    IUserDataRepogitory() = default;
+};
+
+
+template <typename ID, typename UserData>
+class UserDataRepository :
+    public IUserDataRepository<ID, UserData>,
+    public cmp::Singleton<UserDataRepository<ID, UserData>> {
+public: // static_const/enum
+public: // static
+    static bool isExist(ID id) { return instance()->isExist(id); }
+    static const UserData* at(ID id) { return instance()->at(id); }
+    static const Dictionary& data() { return instance()->data(id); }
+public: // public getter
+    bool isExist(ID id) const override { return m_data.contains(id); }
+    const UserData* at(ID id) const override {
+        if (isExist(id)) {
+            return m_data.at(id);
+        }
+        else {
+            return nullptr;
+        }
+    }
+    const Dictionary& data() const override { return m_data; }
+public: // public setter
+    UserData* at(ID id) override { return at(id); }
+    bool add(ID<T> id, const UserData& value) override {
+        if (isExist(id)) {
+            return false;
+        }
+        else {
+            m_data.insert(std::make_pair(id, std::make_unique<UserData>(value)));
+            return true;
+        }
+    }
+    bool erase(ID<T> id) override {
+        if (isExist(id)) {
+            m_data.erase(id);
+            return true;
+        }
+        else {
+            return false;
+        }
+    }
+    
+private: // field
+    Dictionary m_data;
+private: // private function
+public: // ctor/dtor
+};
+
+
+}
+}
+

--- a/component/parameter/HotReloadableParameters.hpp
+++ b/component/parameter/HotReloadableParameters.hpp
@@ -16,6 +16,7 @@ public: // public function
     
     template<typename Type>
     Type get(const s3d::String& key) const { return m_reader[key].get<Type>(); }
+    s3d::TOMLValue getTOML(const s3d::String& key) const { return m_reader[key]; }
     s3d::Vec2 getVec2(const s3d::String& key) const;
     s3d::Size getSize(const s3d::String& key) const;
     s3d::ColorF getColorF(const s3d::String& key) const;


### PR DESCRIPTION

https://github.com/youriko-fanclub/dx4siv3d/pull/19 をまだ見ていなければ先に見てください


- MasterData
	- 個々の漢字のデータ(KanjiID=0, "山", attack=120, ...) みたいなデータたち
		- 大量に存在 or 随時増えていく
		- 企画さんも触る()
		- アプリ側からの変更がない
こいつの作成/運用/実装を上手く管理したい
↓
以下のものを asset/schema/ に置き、 tool/ 以下のpythonスクリプトを用いて取り扱う
- Id空間定義: id.toml : Idの名称とその値の範囲
- 型定義: masterdata.toml : MasterDataの型名とそのメンバ変数
- MasterXXX.hpp: 型定義をC++クラス化したもの。全メンバ変数に対するsetter/getterを持つ
- 実データ: 型定義のいずれかに適合する具体的なデータ
(それぞれ詳しくは https://github.com/youriko-fanclub/KANJI-asset/pull/9 を参照)

KANJI-asset/schema/ : Id空間定義、型定義、実データ、型定義から自動生成されたhpp/cppファイル
tool/ : 各種pythonスクリプト
	- 型定義からhpp/cpp自動生成
	- 実データが型定義に適合しているかのバリデーション
	- Id空間の管理
KANJI-client/ : 自動生成されたhpp/cppを呼び出して利用する